### PR TITLE
fix install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "visits-counter",
     "scripts": {
-        "install": "cd frontend && npm install && cd .. && npm install",
+        "postinstall": "cd frontend && npm install",
         "site": "cd frontend && npm run start",
         "server": "node index.js",
         "prod": "cd frontend && npm run build && cd .. && nodemon index.js"


### PR DESCRIPTION
"npm install" will always install everything from package.json. If you want to build the frontend packages afterwards you need to but it in "postinstall".

The current version is an endless loop.